### PR TITLE
Changes from background agent bc-fff1d5fa-18ea-4fbe-948f-c4d5c47945d8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-decouple==3.8
 dj-database-url==3.0.1
 pandas==2.3.1
 whitenoise==6.6.0
+psycopg[binary]==3.2.3


### PR DESCRIPTION
Add `psycopg[binary]` to `requirements.txt` to resolve PostgreSQL driver import errors on deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-fff1d5fa-18ea-4fbe-948f-c4d5c47945d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fff1d5fa-18ea-4fbe-948f-c4d5c47945d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

